### PR TITLE
#6  Fix flowtype

### DIFF
--- a/src/posts/domain/index.js
+++ b/src/posts/domain/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 const posts = [
   {
     id: 0,

--- a/src/posts/services/index.js
+++ b/src/posts/services/index.js
@@ -3,7 +3,7 @@ import type { Post } from '../typedefs';
 
 import { posts } from '../domain';
 
-function getAllPosts({ limit }: { limit?: Number } = {}): [Post] {
+function getAllPosts({ limit }: { limit?: number } = {}): [Post] {
   if (limit) {
     return posts.slice(0, limit);
   }

--- a/src/posts/typedefs/index.js
+++ b/src/posts/typedefs/index.js
@@ -1,8 +1,8 @@
 // @flow
 
 export type Post = {
-  id: Number,
-  title: String,
-  author?: String,
-  content: String
+  id: number,
+  title: string,
+  author?: string,
+  content: string
 };


### PR DESCRIPTION
Issue: #6

Types should be defined as primitives (lower-case naming), eg. `string` instead `String`.

In Javascript values like number or string can be represented as object (then type should be declared from capital-letter), but we are interested in using them as primitive values.

Example with primitive value and object value:  https://jsbin.com/niwudebagu/edit?js,console